### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/digital-york/researchdatayork.png?label=ready&title=Ready)](https://waffle.io/digital-york/researchdatayork)
 # Research Data York
 
 [![Code Climate](https://codeclimate.com/github/digital-york/researchdatayork/badges/gpa.svg)](https://codeclimate.com/github/digital-york/researchdatayork)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/digital-york/researchdatayork

This was requested by a real person (user geekscruff) on waffle.io, we're not trying to spam you.